### PR TITLE
ci(mergify): Remove default name for queue action

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,6 @@ defaults:
   actions:
     queue:
       allow_merging_configuration_change: true
-      name: default
       method: squash
       commit_message_template: |
         {{ title }} (#{{ number }})


### PR DESCRIPTION
We have queue conditions for every queue now, the default name is useless and breaks the queue conditions injections.

Fixes MRGFY-2394