### PR TITLE
chore: remove bot_account for squash

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,6 @@ defaults:
       allow_merging_configuration_change: true
     squash:
       commit_message: first-commit
-      bot_account: mergify-ci-bot
 
 pull_request_rules:
   - name: dismiss reviews


### PR DESCRIPTION
The command sender or PR author is now used, which is enough for us.