### PR TITLE
ci(mergify): report success on merge queue branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -66,11 +66,12 @@ pull_request_rules:
   - name: Conventional Commit
     conditions:
       - base=main
-      - -head~=^mergify/merge-queue/.*
     actions:
       post_check:
         success_conditions:
-          - "title ~= ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\\))?:"
+          - or:
+            - head ~= ^mergify/merge-queue/
+            - "title ~= ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\\))?:"
         title: |
           {% if check_succeed %}
           Title follows Conventional Commit


### PR DESCRIPTION
We could also use neutral, but that'd require fixing every configuration to allow neutral for this check.
