### PR TITLE
ci: add labels to ci-bot pull request

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -100,6 +100,6 @@ pull_request_rules:
       - head=trivy/daily-report
       - "body~=New CVEs:"
     actions:
-      labels:
+      label:
         add:
           - new CVE

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -89,7 +89,7 @@ pull_request_rules:
       - head~=^clifus/
       - "title~=^chore: bump"
     actions:
-      labels:
+      label:
         add:
           - dependencies
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -81,3 +81,25 @@ pull_request_rules:
           The pull request title must follow
           [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/).
           {% endif %}
+
+  - name: Clifus labels
+    conditions:
+      - base=main
+      - author=mergify-ci-bot
+      - head~=^clifus/
+      - "title~=^chore: bump"
+    actions:
+      labels:
+        add:
+          - dependencies
+
+  - name: Trivy label
+    conditions:
+      - base=main
+      - author=mergify-ci-bot
+      - head=trivy/daily-report
+      - "body~=New CVEs:"
+    actions:
+      labels:
+        add:
+          - new CVE


### PR DESCRIPTION
As the new ci-bot does not have write access anymore to our repo it can't set the labels.

This change set them with Mergify instead.