### PR TITLE
chore(mergify): remove `allow_merging_configuration_change`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,5 @@
 defaults:
   actions:
-    queue:
-      allow_merging_configuration_change: true
     squash:
       commit_message: first-commit
 pull_request_rules:


### PR DESCRIPTION
This option isn't necessary anymore. It's not used in the engine anymore.