### PR TITLE
chore(mergify): fix conventional commit protection

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -77,4 +77,4 @@ merge_protections:
     success_conditions:
       - >-
         title ~=
-        ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:(.+))?:
+        ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\\))?:


### PR DESCRIPTION
We have to escape the parenthesis to match them explicitly.