### PR TITLE
revert: "chore(mergify): fix conventional commit protection"

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -77,4 +77,4 @@ merge_protections:
     success_conditions:
       - >-
         title ~=
-        ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\\))?:
+        ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:(.+))?:


### PR DESCRIPTION
The fix isn't working correctly, might need some better testing before merging it again

Reverts Mergifyio/.github#29