### PR TITLE
chore: remove ping when CI failure

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,14 +24,6 @@ pull_request_rules:
       label:
         toggle:
           - review threads unresolved
-  - name: warn on CI failure for hotfix
-    conditions:
-      - '-closed'
-      - label=hotfix
-      - '#check-failure>0'
-    actions:
-      comment:
-        message: Your hotfix is failing CI @{{author}} 🥺
   - name: label on queued
     conditions:
       - queue-position>=0


### PR DESCRIPTION
With MP, this doesn't work well as the MP check-run is always red until
all MP rules pass.