### PR TITLE
ci: allow 'ui' conventional commit prefix

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -39,7 +39,7 @@ merge_protections:
     success_conditions:
       - >-
         title ~=
-        ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\(.+\))?:
+        ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert|ui)(?:\(.+\))?:
 
   - name: 🔎 Reviews
     if: []


### PR DESCRIPTION
Let PR titles use 'ui:' for visual/UX polish in frontend projects —
restyling, layout tweaks, copy adjustments, animations — that aren't
new features ('feat'), broken UI fixes ('fix'), or code formatting
('style').